### PR TITLE
Add support update AAAA record type and this file can be a module now

### DIFF
--- a/ddns_manager.py
+++ b/ddns_manager.py
@@ -150,6 +150,7 @@ class NameSilo_APIv1:
                 )
             )
         log('{} records retrieved for {}'.format(len(self.current_records), self.domain))
+        log(self.current_records)
 
     def dynamic_dns_update(self, ip):
         """Dynamic DNS updater"""
@@ -207,11 +208,10 @@ class NameSilo_APIv1:
 #######################################################################################################################
 # In development, too tired.
 _log = []
-_current_ip = _web_worker.get('https://api.ipify.org/?format=json').json()['ip']  # GET our current IP.
 
 
 def log(message):
-    #  print(message)
+    print(message)
     _log.append(message)
 
 
@@ -245,4 +245,6 @@ def send_message():
     sg.client.mail.send.post(request_body=build_message())
 
 
-update_records()
+if __name__=="__main__":
+    _current_ip = _web_worker.get('https://api.ipify.org/?format=json').json()['ip']  # GET our current IP.
+    update_records()


### PR DESCRIPTION
IPv6 is more common now. AAAA(IPv6) record now supported to update. User just need to call old function and pass IP. The record will be adjusted automatically by IP type.

User may want include this python as a module instead of use it directly. Support now.