### PR TITLE
Fix example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ```
  record_ttl = '7207'
  domains_and_hosts = (
-     ["namesilo.com", ["", "www", "mail"]]  # This will update namesilo.com, www.namesilo.com, and mail.namesilo.com.
+     ["namesilo.com", ["", "www", "mail"]],  # This will update namesilo.com, www.namesilo.com, and mail.namesilo.com.
  )
 ```
 - Example configuration for multiple domains and hosts (without email notification):


### PR DESCRIPTION
Tuples with one element (only one domain here) need to include a `,` at the end. Otherwise unpacking it will fail in the loop in `update_records()`.