### PR TITLE
implement dnsAddRecord and dnsDeleteRecord, and dns update now support update any kind of record besides IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,66 @@ email_to_addresses = ["jane.doe@company", "john.doe@company", "my.manager@somebu
 subject = "DNS update notification, timestamped: " + strftime('%x %H:%M:%S')  # Subject line.
 ```
 
+# Usage Examples
+
+## Update/Add IPv4/IPv6 record
+
+The following 2 lines will update A record of www.xxx.com and test.xxx.com to 1.2.3.4, if any of them doesn't exist, it will be created automatically
+
+```python
+import ddns_manager
+api = ddns_manager.NameSilo_APIv1("xxx.com", ["www", "test"])
+api.dynamic_dns_update("1.2.3.4")
+```
+
+## Update/Add specific type record
+
+The valid type will be:
+
+- A - The IPV4 Address
+- AAAA - The IPV6 Address
+- CNAME - The Target Hostname
+- MX - The Target Hostname
+- TXT - The Text
+
+The following 2 lines will update/create a TXT record of _acme-challenge.xxx.com and its value is utpEMa5B58CMdjTJCLnB5XxcmZ0CoCP6PFdmqE5bIpo.
+
+```python
+import ddns_manager
+api = ddns_manager.NameSilo_APIv1("xxx.com", ["_acme-challenge"])
+api.dynamic_dns_update("utpEMa5B58CMdjTJCLnB5XxcmZ0CoCP6PFdmqE5bIpo", "TXT")
+
+# You may want to create a record without checking if it exists or not.
+api.dynamic_dns_add("www", "2001::3", "AAAA")
+```
+
+## Delete record
+
+This delete function will delete all the records which match the conditions user offered. User can offer host, value, type as delete function paramter, all the parameters are optional.
+If no parameter given, means all the namesilo records belongs to this domain will be deleted.
+
+```python
+import ddns_manager
+
+api = ddns_manager.NameSilo_APIv1("xxx.com")
+
+# Delete _acme-challenge.xxx.com TXT record with value utpEMa5B58CMdjTJCLnB5XxcmZ0CoCP6PFdmqE5bIpo
+api.dynamic_dns_delete("_acme-challenge", "utpEMa5B58CMdjTJCLnB5XxcmZ0CoCP6PFdmqE5bIpo", 'TXT')
+
+# Delete all AAAA records
+api.dynamic_dns_delete(type="AAAA")
+
+# Delete all www records
+api.dynamic_dns_delete(host_without_domain="www")
+
+# Delete all records which value is "4.5.6.7"
+api.dynamic_dns_delete(value="4.5.6.7")
+
+# Delete any records belongs to this domain
+api.dynamic_dns_delete()
+```
+
+
 # How To
 
 1. Generate and save an API key from NameSilo. See [NameSilo](https://www.namesilo.com/Support/Account-Options) for help.

--- a/ddns_manager.py
+++ b/ddns_manager.py
@@ -68,7 +68,7 @@ subject = "DNS update notification, timestamped: " + strftime('%x %H:%M:%S')  # 
 #######################################################################################################################
 namesilo_api_key = os.environ.get('NAMESILO_API_KEY')
 NAMESILO_COM_API = 'https://www.namesilo.com/api'
-NAMESILO_API_IMPLEMENTED_OPERATIONS = {'dnsListRecords', 'dnsUpdateRecord'}
+NAMESILO_API_IMPLEMENTED_OPERATIONS = {'dnsListRecords', 'dnsUpdateRecord', 'dnsAddRecord', 'dnsDeleteRecord'}
 
 _web_worker = requests.session()  # Requests session instance.
 
@@ -141,6 +141,7 @@ class NameSilo_APIv1:
         """Retrieve current Resource Records from NameSilo for self.domain."""
         log('Retrieving records for {}'.format(self.domain))
         current_records = self._api_connection('dnsListRecords')
+        self.current_records = []
         for current_resource_record in current_records.iter('resource_record'):
             self.current_records.append(
                 dict(
@@ -164,7 +165,7 @@ class NameSilo_APIv1:
         else:
             record_type = 'AAAA'
         log('DDNS update starting for domain: {} and record type {}'.format(self.domain, record_type))
-        # Generator for hosts that require an A record update.
+        # Generator for hosts that require an record update.
         hosts_requiring_updates = (
             record for record
             in self.current_records
@@ -198,8 +199,78 @@ class NameSilo_APIv1:
                 pass
             _count += 1
             log('DDNS successfully updated {}'.format(host['host']))
-        log('DDNS update complete for {}.  {} hosts required updates. {} errors.'.format(self.domain, _count, _failed))
+        log('DDNS update complete for {}.  {} hosts required updates. {} errors.'.format(
+            self.domain, _count, _failed))
 
+        # List for hosts that reuire an record create.
+        hosts_requiring_adds = [
+            host for host
+            in self.hosts.keys()
+            if not any(record.get('host', None) == host for record in self.current_records)
+        ]
+        log('DDNS add required for {}'.format(hosts_requiring_adds))
+        for host in hosts_requiring_adds:
+            self.dynamic_dns_add(self.hosts[host], ip, record_type)
+
+    def dynamic_dns_add(self, host_without_domain, value, type):
+        __api_params = {
+            'rrtype': type,
+            'rrhost': host_without_domain,
+            'rrvalue': value,
+            'rrttl': record_ttl,
+        }
+        try:
+            self._api_connection('dnsAddRecord', **__api_params)
+        except ValueError:
+            log('DDNS failed to add {}, type {}, value {}'.format(host_without_domain, 
+            type, value))
+            return
+        except NotImplementedError:
+            log('DDNS failed to add {}, type {}, value {}'.format(host_without_domain, 
+            type, value))
+            return
+        log('DDNS successfully add {}, type {}, value {}'.format(host_without_domain, 
+            type, value))
+        self.retrieve_resource_records()  # re-populate.
+
+    # Any of the parameter can be None and if all of the parameters are None, 
+    # means delete all records for this domain
+    def dynamic_dns_delete(self, host_without_domain=None, value=None, type=None):
+        log('DDNS delete starting for domain: {}, host {}, type {}, value {}'.format(
+            self.domain, host_without_domain, type, value))
+        hosts_requiring_deletes = []
+        for record in self.current_records:
+            flag = True
+            if host_without_domain:
+                flag = flag and (record['host'] == (str.join('.', 
+                [host_without_domain, self.domain]) if host_without_domain != '' else self.domain))
+            if value:
+                flag = flag and (record['value'] == value)
+            if type:
+                flag = flag and (record['type'] == type)
+            if flag:
+                hosts_requiring_deletes.append(record)
+        _count = 0
+        _failed = 0
+        for host in hosts_requiring_deletes:
+            __api_params = {
+                'rrid': host['record_id'],
+            }
+            try:
+                self._api_connection('dnsDeleteRecord', **__api_params)
+            except ValueError:
+                log('DDNS failed to delete {}'.format(host_without_domain))
+                _failed += 1
+                pass
+            except NotImplementedError:
+                log('DDNS failed to delete {}'.format(host_without_domain))
+                _failed += 1
+                pass
+            _count += 1
+            log('DDNS successfully delete {}'.format(host_without_domain))
+        log('DDNS delete complete for {}.  {} hosts required updates. {} errors.'.format(
+            self.domain, _count, _failed))
+        self.retrieve_resource_records()  # re-populate.
 
 #######################################################################################################################
 #######################################################################################################################


### PR DESCRIPTION
Hi,

I commit 2 changes to my forked code. 
The first change is about to add implementation for dnsAddRecord and dnsDeleteRecord. One enhancement is that, if the user defined hosts is not in namesilo record, it will be created automatically now. 

The second change is about to make dynamic_dns_update to become a common interface, not just for A and AAAA type. It keeps the backward compatibility which won't break the existing logic. The background of this: I may want to call this function as a module in another py file to update namesilo record such like TXT etc..

Please approve it if you are feeling OK about the change. 